### PR TITLE
allow comments inline for trusted_proxya textarea

### DIFF
--- a/pas/plugins/trustedproxyauth/plugin.py
+++ b/pas/plugins/trustedproxyauth/plugin.py
@@ -180,6 +180,8 @@ class TrustedProxyAuthPlugin(BasePlugin, Cacheable):
             return None
 
         for idx, addr in enumerate(self.trusted_proxies):
+            #remove comment from addr
+            addr = re.sub(r'(?m) *#.*\n?', '', addr).strip()
             if IS_IP.match(addr):
                 continue
             # If it's not an IP, then it's a hostname, and we need to


### PR DESCRIPTION
this patch allows to add comments inline for the trusted_proxies textarea. comments like 
172.168.0.1 # this is my first trusted proxy
will be removed before trying to handle the addr as IP or hostname